### PR TITLE
Add Settings finder by app id

### DIFF
--- a/Model/Settings.php
+++ b/Model/Settings.php
@@ -14,6 +14,17 @@ class Aerosalloyalty_Model_Settings extends Core_Model_Default
         return $this;
     }
 
+    public function findByAppId(int $app_id) {
+        $row = $this->_db_table->fetchRow(['app_id = ?' => $app_id]);
+        if ($row) {
+            $this->setData($row->toArray());
+            return $this;
+        }
+
+        $this->setData([]);
+        return null;
+    }
+
     public function upsert(array $data) {
         $value_id = (int)$data['value_id'];
         $row = $this->_db_table->fetchRow(['value_id = ?' => $value_id]);


### PR DESCRIPTION
## Summary
- add a helper on the settings model to fetch records by `app_id`
- clear model data and return null when no record is found so callers can detect missing apps

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68da4bf4e2588326947c7162a56c7d59