### PR TITLE
Add public campaign endpoints and token management

### DIFF
--- a/Model/ApiToken.php
+++ b/Model/ApiToken.php
@@ -24,6 +24,34 @@ class Aerosalloyalty_Model_ApiToken extends Core_Model_Default
         return true;
     }
 
+    public function getActiveTokenForValue($value_id) {
+        $row = $this->_db_table->fetchRow([
+            'value_id = ?' => (int)$value_id,
+            'is_active = ?' => 1
+        ], 'aerosalloyalty_api_token_id DESC');
+
+        if ($row) {
+            $this->setData($row->toArray());
+        } else {
+            $this->setData([]);
+        }
+
+        return $this;
+    }
+
+    public function deactivateAllForValue($value_id) {
+        return $this->_db_table->update(
+            ['is_active' => 0],
+            ['value_id = ?' => (int)$value_id]
+        );
+    }
+
+    public static function generateTokenString($length = 48) {
+        $length = max(16, (int)$length);
+        $bytesLength = (int)ceil($length / 2);
+        return substr(bin2hex(random_bytes($bytesLength)), 0, $length);
+    }
+
     public function createToken($value_id, $plainToken) {
         $id = $this->_db_table->insert([
             'value_id'   => (int)$value_id,
@@ -32,5 +60,21 @@ class Aerosalloyalty_Model_ApiToken extends Core_Model_Default
             'created_at' => date('Y-m-d H:i:s')
         ]);
         return $this->find($id);
+    }
+
+    public function ensureToken($value_id) {
+        $this->getActiveTokenForValue($value_id);
+        if ($this->getId()) {
+            return $this;
+        }
+
+        $plain = self::generateTokenString();
+        return $this->createToken($value_id, $plain);
+    }
+
+    public function regenerateToken($value_id) {
+        $this->deactivateAllForValue($value_id);
+        $plain = self::generateTokenString();
+        return $this->createToken($value_id, $plain);
     }
 }

--- a/Model/Campaign.php
+++ b/Model/Campaign.php
@@ -32,6 +32,37 @@ class Aerosalloyalty_Model_Campaign extends Core_Model_Default
         return $this;
     }
 
+    public static function generateUid($value_id, $card_number, $length = 16) {
+        $length = max(8, (int)$length);
+        do {
+            $bytes = bin2hex(random_bytes((int)ceil($length / 2)));
+            $uid   = strtoupper(substr($bytes, 0, $length));
+            $existing = (new self())->findByUid($value_id, $uid, $card_number);
+        } while ($existing && $existing->getId());
+
+        return $uid;
+    }
+
+    public function findByUid($value_id, $uid, $card_number = null) {
+        $where = [
+            'value_id = ?'    => (int)$value_id,
+            'campaign_uid = ?'=> (string)$uid
+        ];
+
+        if ($card_number !== null) {
+            $where['card_number = ?'] = (string)$card_number;
+        }
+
+        $row = $this->_db_table->fetchRow($where);
+        if ($row) {
+            $this->setData($row->toArray());
+        } else {
+            $this->setData([]);
+        }
+
+        return $this;
+    }
+
     public function deleteByUid($value_id, $card_number, $uid) {
         return $this->_db_table->delete([
             'value_id = ?'     => (int)$value_id,

--- a/Model/Card.php
+++ b/Model/Card.php
@@ -24,7 +24,8 @@ class Aerosalloyalty_Model_Card extends Core_Model_Default
     {
         $row = $this->_db_table->fetchRow([
             'value_id = ?'   => (int)$value_id,
-            'card_number = ?' => (string)$card_number
+            'card_number = ?' => (string)$card_number,
+            'deleted_at IS NULL'
         ]);
         if ($row) $this->setData($row->toArray());
         return $this;

--- a/controllers/ApplicationController.php
+++ b/controllers/ApplicationController.php
@@ -54,6 +54,48 @@ class Aerosalloyalty_ApplicationController extends Application_Controller_Defaul
         }
     }
 
+    /** API TOKEN — fetch active token (GET) */
+    public function getApiTokenAction()
+    {
+        try {
+            $value_id = (int)$this->getRequest()->getParam('value_id');
+            if (!$value_id) throw new Exception('Missing value_id');
+
+            $token = (new Aerosalloyalty_Model_ApiToken())->ensureToken($value_id);
+
+            return $this->_sendJson([
+                'success' => 1,
+                'token' => $token->getToken(),
+                'last_used_at' => $token->getLastUsedAt()
+            ]);
+        } catch (Exception $e) {
+            return $this->_sendJson(['error' => 1, 'message' => $e->getMessage()]);
+        }
+    }
+
+    /** API TOKEN — regenerate (POST) */
+    public function regenerateApiTokenAction()
+    {
+        if (!$this->getRequest()->isPost()) {
+            return $this->_sendJson(['error' => 1, 'message' => 'Invalid request']);
+        }
+
+        try {
+            $value_id = (int)$this->getRequest()->getPost('value_id');
+            if (!$value_id) throw new Exception('Missing value_id');
+
+            $token = (new Aerosalloyalty_Model_ApiToken())->regenerateToken($value_id);
+
+            return $this->_sendJson([
+                'success' => 1,
+                'token' => $token->getToken(),
+                'last_used_at' => $token->getLastUsedAt()
+            ]);
+        } catch (Exception $e) {
+            return $this->_sendJson(['error' => 1, 'message' => $e->getMessage()]);
+        }
+    }
+
     /** CAMPAIGN TYPES — list (GET) */
     public function listTypesAction()
     {

--- a/controllers/Public/CampaignController.php
+++ b/controllers/Public/CampaignController.php
@@ -1,0 +1,340 @@
+<?php
+
+class Aerosalloyalty_Public_CampaignController extends Application_Controller_Default
+{
+    protected function authenticateToken()
+    {
+        $header = trim((string)$this->getRequest()->getHeader('Authorization'));
+        if (!$header || stripos($header, 'Bearer ') !== 0) {
+            throw new Exception('Unauthorized', 401);
+        }
+
+        $token = trim(substr($header, 7));
+        if ($token === '') {
+            throw new Exception('Unauthorized', 401);
+        }
+
+        $model = new Aerosalloyalty_Model_ApiToken();
+        if (!$model->validate($token)) {
+            throw new Exception('Unauthorized', 401);
+        }
+
+        return $model;
+    }
+
+    protected function resolveSettings($appId)
+    {
+        $appId = (int)$appId;
+        if ($appId <= 0) {
+            throw new Exception('Missing app_id', 400);
+        }
+
+        $settings = new Aerosalloyalty_Model_Settings();
+        $result   = $settings->findByAppId($appId);
+        if (!$result || !$settings->getId()) {
+            throw new Exception('Feature not configured for provided app_id', 404);
+        }
+
+        return $settings;
+    }
+
+    protected function parseJsonBody()
+    {
+        $raw = $this->getRequest()->getRawBody();
+        if (!strlen(trim($raw))) {
+            return [];
+        }
+
+        $data = json_decode($raw, true);
+        return is_array($data) ? $data : [];
+    }
+
+    protected function safeLog($valueId, $direction, $status, ?array $payload = null)
+    {
+        try {
+            $json = $payload !== null
+                ? json_encode($payload, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)
+                : null;
+            (new Aerosalloyalty_Model_WebhookLog())->log(
+                (int)$valueId,
+                $direction,
+                (string)$this->getRequest()->getRequestUri(),
+                $status,
+                $json
+            );
+        } catch (Exception $e) {
+            // Swallow logging issues to avoid breaking main flow
+        }
+    }
+
+    public function postAction()
+    {
+        $valueId = null;
+
+        try {
+            $tokenModel = $this->authenticateToken();
+            $appId      = $this->getRequest()->getParam('app_id');
+            $settings   = $this->resolveSettings($appId);
+            $valueId    = (int)$settings->getValueId();
+
+            if ((int)$tokenModel->getValueId() !== $valueId) {
+                throw new Exception('Token does not grant access to this feature', 403);
+            }
+
+            $body = $this->parseJsonBody();
+
+            $cardNumber = trim((string)($this->getRequest()->getParam('card_number', $body['card_number'] ?? '')));
+            if ($cardNumber === '') {
+                throw new Exception('Missing card_number', 400);
+            }
+
+            $card = (new Aerosalloyalty_Model_Card())->findByValueAndNumber($valueId, $cardNumber);
+            if (!$card->getId()) {
+                throw new Exception('Card not found for provided value_id', 404);
+            }
+
+            $typeCode = trim((string)($this->getRequest()->getParam('campaign_type_code', $body['campaign_type_code'] ?? '')));
+            if ($typeCode === '') {
+                throw new Exception('Missing campaign_type_code', 400);
+            }
+
+            $type = (new Aerosalloyalty_Model_CampaignType())->findByCode($valueId, $typeCode);
+            if (!$type->getId()) {
+                throw new Exception('Unknown campaign_type_code', 404);
+            }
+
+            $name = trim((string)($this->getRequest()->getParam('name', $body['name'] ?? '')));
+            if ($name === '') {
+                throw new Exception('Missing name', 400);
+            }
+
+            $points = $this->getRequest()->getParam('points_balance', $body['points_balance'] ?? 0);
+            $points = (int)$points;
+
+            $prizes = $this->getRequest()->getParam('prizes', $body['prizes'] ?? null);
+            $prizes = $prizes !== null ? (string)$prizes : null;
+
+            $this->safeLog($valueId, 'inbound', null, [
+                'method' => 'POST',
+                'payload' => [
+                    'app_id'             =>(int)$appId,
+                    'card_number'        =>$cardNumber,
+                    'campaign_type_code' =>$typeCode,
+                    'name'               =>$name,
+                    'points_balance'     =>$points,
+                    'prizes'             =>$prizes,
+                ],
+            ]);
+
+            $uid = Aerosalloyalty_Model_Campaign::generateUid($valueId, $cardNumber);
+
+            $campaign = (new Aerosalloyalty_Model_Campaign())->upsert([
+                'value_id'           => $valueId,
+                'card_number'        => $cardNumber,
+                'campaign_uid'       => $uid,
+                'campaign_type_code' => $typeCode,
+                'name'               => $name,
+                'points_balance'     => $points,
+                'prizes'             => $prizes,
+            ]);
+
+            $response = [
+                'success'  => 1,
+                'campaign' => [
+                    'value_id'           => $campaign->getValueId(),
+                    'card_number'        => $campaign->getCardNumber(),
+                    'campaign_uid'       => $campaign->getCampaignUid(),
+                    'campaign_type_code' => $campaign->getCampaignTypeCode(),
+                    'name'               => $campaign->getName(),
+                    'points_balance'     => (int)$campaign->getPointsBalance(),
+                    'prizes'             => $campaign->getPrizes(),
+                ],
+            ];
+
+            $this->safeLog($valueId, 'outbound', 201, $response);
+            $this->getResponse()->setHttpResponseCode(201);
+            return $this->_sendJson($response);
+        } catch (Exception $e) {
+            $status = ($e->getCode() >= 400 && $e->getCode() < 600) ? $e->getCode() : 500;
+            if ($valueId !== null) {
+                $this->safeLog($valueId, 'outbound', $status, ['error' => 1, 'message' => $e->getMessage()]);
+            }
+            $this->getResponse()->setHttpResponseCode($status);
+            return $this->_sendJson(['error' => 1, 'message' => $e->getMessage()]);
+        }
+    }
+
+    public function putAction()
+    {
+        $valueId = null;
+
+        try {
+            $tokenModel = $this->authenticateToken();
+            $appId      = $this->getRequest()->getParam('app_id');
+            $settings   = $this->resolveSettings($appId);
+            $valueId    = (int)$settings->getValueId();
+
+            if ((int)$tokenModel->getValueId() !== $valueId) {
+                throw new Exception('Token does not grant access to this feature', 403);
+            }
+
+            $uid = trim((string)$this->getRequest()->getParam('uid'));
+            if ($uid === '') {
+                throw new Exception('Missing campaign uid', 400);
+            }
+
+            $body = $this->parseJsonBody();
+
+            $cardNumber = $this->getRequest()->getParam('card_number', $body['card_number'] ?? null);
+            $cardNumber = $cardNumber !== null ? trim((string)$cardNumber) : null;
+
+            $campaignModel = new Aerosalloyalty_Model_Campaign();
+            $campaign      = $campaignModel->findByUid($valueId, $uid, $cardNumber);
+            if (!$campaign->getId()) {
+                $campaign = $campaignModel->findByUid($valueId, $uid);
+            }
+
+            if (!$campaign->getId()) {
+                throw new Exception('Campaign not found', 404);
+            }
+
+            $cardNumber = $cardNumber ?: $campaign->getCardNumber();
+
+            $card = (new Aerosalloyalty_Model_Card())->findByValueAndNumber($valueId, $cardNumber);
+            if (!$card->getId()) {
+                throw new Exception('Card not found for provided value_id', 404);
+            }
+
+            $typeCode = $this->getRequest()->getParam('campaign_type_code', $body['campaign_type_code'] ?? $campaign->getCampaignTypeCode());
+            $typeCode = trim((string)$typeCode);
+            if ($typeCode === '') {
+                throw new Exception('Missing campaign_type_code', 400);
+            }
+
+            $type = (new Aerosalloyalty_Model_CampaignType())->findByCode($valueId, $typeCode);
+            if (!$type->getId()) {
+                throw new Exception('Unknown campaign_type_code', 404);
+            }
+
+            $name = $this->getRequest()->getParam('name', $body['name'] ?? $campaign->getName());
+            $name = trim((string)$name);
+            if ($name === '') {
+                throw new Exception('Missing name', 400);
+            }
+
+            $points = $this->getRequest()->getParam('points_balance', $body['points_balance'] ?? $campaign->getPointsBalance());
+            $points = (int)$points;
+
+            $prizes = $this->getRequest()->getParam('prizes', array_key_exists('prizes', $body) ? $body['prizes'] : $campaign->getPrizes());
+            $prizes = $prizes !== null ? (string)$prizes : null;
+
+            $this->safeLog($valueId, 'inbound', null, [
+                'method' => 'PUT',
+                'payload' => [
+                    'app_id'             => (int)$appId,
+                    'uid'                => $uid,
+                    'card_number'        => $cardNumber,
+                    'campaign_type_code' => $typeCode,
+                    'name'               => $name,
+                    'points_balance'     => $points,
+                    'prizes'             => $prizes,
+                ],
+            ]);
+
+            $campaign = $campaignModel->upsert([
+                'value_id'           => $valueId,
+                'card_number'        => $cardNumber,
+                'campaign_uid'       => $uid,
+                'campaign_type_code' => $typeCode,
+                'name'               => $name,
+                'points_balance'     => $points,
+                'prizes'             => $prizes,
+            ]);
+
+            $response = [
+                'success'  => 1,
+                'campaign' => [
+                    'value_id'           => $campaign->getValueId(),
+                    'card_number'        => $campaign->getCardNumber(),
+                    'campaign_uid'       => $campaign->getCampaignUid(),
+                    'campaign_type_code' => $campaign->getCampaignTypeCode(),
+                    'name'               => $campaign->getName(),
+                    'points_balance'     => (int)$campaign->getPointsBalance(),
+                    'prizes'             => $campaign->getPrizes(),
+                ],
+            ];
+
+            $this->safeLog($valueId, 'outbound', 200, $response);
+            $this->getResponse()->setHttpResponseCode(200);
+            return $this->_sendJson($response);
+        } catch (Exception $e) {
+            $status = ($e->getCode() >= 400 && $e->getCode() < 600) ? $e->getCode() : 500;
+            if ($valueId !== null) {
+                $this->safeLog($valueId, 'outbound', $status, ['error' => 1, 'message' => $e->getMessage()]);
+            }
+            $this->getResponse()->setHttpResponseCode($status);
+            return $this->_sendJson(['error' => 1, 'message' => $e->getMessage()]);
+        }
+    }
+
+    public function deleteAction()
+    {
+        $valueId = null;
+
+        try {
+            $tokenModel = $this->authenticateToken();
+            $appId      = $this->getRequest()->getParam('app_id');
+            $settings   = $this->resolveSettings($appId);
+            $valueId    = (int)$settings->getValueId();
+
+            if ((int)$tokenModel->getValueId() !== $valueId) {
+                throw new Exception('Token does not grant access to this feature', 403);
+            }
+
+            $uid = trim((string)$this->getRequest()->getParam('uid'));
+            if ($uid === '') {
+                throw new Exception('Missing campaign uid', 400);
+            }
+
+            $body = $this->parseJsonBody();
+
+            $cardNumber = $this->getRequest()->getParam('card_number', $body['card_number'] ?? null);
+            $cardNumber = $cardNumber !== null ? trim((string)$cardNumber) : null;
+
+            $campaignModel = new Aerosalloyalty_Model_Campaign();
+            $campaign      = $campaignModel->findByUid($valueId, $uid, $cardNumber);
+            if (!$campaign->getId()) {
+                $campaign = $campaignModel->findByUid($valueId, $uid);
+            }
+
+            if (!$campaign->getId()) {
+                throw new Exception('Campaign not found', 404);
+            }
+
+            $cardNumber = $campaign->getCardNumber();
+
+            $this->safeLog($valueId, 'inbound', null, [
+                'method' => 'DELETE',
+                'payload' => [
+                    'app_id'      => (int)$appId,
+                    'uid'         => $uid,
+                    'card_number' => $cardNumber,
+                ],
+            ]);
+
+            $campaignModel->deleteByUid($valueId, $cardNumber, $uid);
+
+            $this->safeLog($valueId, 'outbound', 204, ['success' => 1]);
+            $this->getResponse()->setHttpResponseCode(204);
+            $this->getResponse()->setBody('');
+            return;
+        } catch (Exception $e) {
+            $status = ($e->getCode() >= 400 && $e->getCode() < 600) ? $e->getCode() : 500;
+            if ($valueId !== null) {
+                $this->safeLog($valueId, 'outbound', $status, ['error' => 1, 'message' => $e->getMessage()]);
+            }
+            $this->getResponse()->setHttpResponseCode($status);
+            return $this->_sendJson(['error' => 1, 'message' => $e->getMessage()]);
+        }
+    }
+}

--- a/resources/design/desktop/flat/template/aerosalloyalty/application/edit.phtml
+++ b/resources/design/desktop/flat/template/aerosalloyalty/application/edit.phtml
@@ -49,6 +49,27 @@ if (substr($base_url, -1) !== '/') $base_url .= '/';
             <input type="hidden" name="value_id" value="<?php echo (int) $value_id; ?>">
             <input type="hidden" name="app_id" value="<?php echo (int) $app_id; ?>">
 
+            <!-- API Token -->
+            <div class="form-group row mb-4 mt-4">
+              <label class="col-sm-3 col-form-label fw-bold">
+                <?php echo p__("Aerosalloyalty", "API Token"); ?>
+              </label>
+              <div class="col-sm-7">
+                <div class="input-group">
+                  <input type="text" class="form-control input-flat" id="api_token_value" readonly="readonly" placeholder="<?php echo p__("Aerosalloyalty", "Token will appear after loading"); ?>">
+                  <button type="button" class="btn btn-default" id="btn_copy_api_token">
+                    <i class="fa fa-copy"></i> <?php echo p__("Aerosalloyalty", "Copy"); ?>
+                  </button>
+                  <button type="button" class="btn btn-warning" id="btn_regenerate_api_token">
+                    <i class="fa fa-refresh"></i> <?php echo p__("Aerosalloyalty", "Regenerate"); ?>
+                  </button>
+                </div>
+                <small class="form-text text-muted">
+                  <?php echo p__("Aerosalloyalty", "Send this token as Authorization: Bearer when calling the public campaign endpoints."); ?>
+                </small>
+              </div>
+            </div>
+
             <!-- Default EAN Encoding -->
             <div class="form-group row mb-4 mt-4">
               <label for="default_ean_encoding" class="col-sm-3 col-form-label fw-bold">
@@ -277,6 +298,37 @@ if (substr($base_url, -1) !== '/') $base_url .= '/';
             <li><?php echo p__('Aerosalloyalty', 'You can validate requests by restricting the URL and/or network firewall.'); ?></li>
           </ul>
         </div>
+        <div class="card shadow-sm rounded-2xl p-5 bg-white mt-4">
+          <h4><?php echo p__('Aerosalloyalty', 'Public Campaign API'); ?></h4>
+          <p class="alert alert-info">
+            <?php echo p__('Aerosalloyalty', 'Use the generated API token with the Authorization: Bearer header. All parameters are passed as query strings (e.g., ?app_id=XX&card_number=YY).'); ?>
+          </p>
+          <h5><?php echo p__('Aerosalloyalty', 'Endpoints'); ?></h5>
+          <ul>
+            <li>
+              <code>POST /public/loyalty/campaigns?app_id={APP_ID}&card_number={CARD_NUMBER}</code><br>
+              <?php echo p__('Aerosalloyalty', 'Body (JSON): {"campaign_type_code":"promo","name":"Back to School","points_balance":120,"prizes":"T-shirt"}'); ?><br>
+              <?php echo p__('Aerosalloyalty', 'Response: 201 Created with the persisted campaign (server assigns campaign_uid).'); ?>
+            </li>
+            <li class="mt-3">
+              <code>PUT /public/loyalty/campaigns/{UID}?app_id={APP_ID}&card_number={CARD_NUMBER}</code><br>
+              <?php echo p__('Aerosalloyalty', 'Body (JSON): provide any updatable fields (campaign_type_code, name, points_balance, prizes).'); ?><br>
+              <?php echo p__('Aerosalloyalty', 'Response: 200 OK with the refreshed campaign payload.'); ?>
+            </li>
+            <li class="mt-3">
+              <code>DELETE /public/loyalty/campaigns/{UID}?app_id={APP_ID}&card_number={CARD_NUMBER}</code><br>
+              <?php echo p__('Aerosalloyalty', 'Response: 204 No Content on success.'); ?>
+            </li>
+          </ul>
+          <h5 class="mt-4"><?php echo p__('Aerosalloyalty', 'Requirements'); ?></h5>
+          <ul>
+            <li><?php echo p__('Aerosalloyalty', 'Authorization header must be present: Authorization: Bearer &lt;API_TOKEN&gt;.'); ?></li>
+            <li><?php echo p__('Aerosalloyalty', 'app_id is required and is resolved through the feature settings.'); ?></li>
+            <li><?php echo p__('Aerosalloyalty', 'card_number must reference an active card (soft-deleted cards are rejected).'); ?></li>
+            <li><?php echo p__('Aerosalloyalty', 'campaign_type_code must exist for the same feature.'); ?></li>
+            <li><?php echo p__('Aerosalloyalty', 'All requests and responses are logged for auditing (Aerosalloyalty → Webhook logs).'); ?></li>
+          </ul>
+        </div>
       </div>
     </div>
 
@@ -339,6 +391,7 @@ if (substr($base_url, -1) !== '/') $base_url .= '/';
     var app_id = <?php echo (int)$app_id; ?>;
     // DataTable instance for Campaign Types
     var dt_object = null;
+    var api_token = '';
 
     function ensureTypesDataTable() {
       if (!$.fn.DataTable) return; // DataTables not loaded; skip
@@ -398,6 +451,9 @@ if (substr($base_url, -1) !== '/') $base_url .= '/';
           $('#enable_check_benefits').prop('checked', !!(+(s.enable_check_benefits || 0)));
           $('#webhook_url').val(s.webhook_url || '');
           renderTypes((res && res.types) || []);
+          renderCampaigns((res && res.campaigns) || []);
+          ensureTypesDataTable();
+          loadApiToken();
         })
         .fail(function(err) {
           console.log(err);
@@ -660,6 +716,88 @@ if (substr($base_url, -1) !== '/') $base_url .= '/';
         $tb.append($tr);
       });
     }
+
+    function setApiToken(token, lastUsed) {
+      api_token = token || '';
+      $('#api_token_value').val(api_token);
+      if (lastUsed) {
+        $('#api_token_value').attr('data-last-used', lastUsed);
+      }
+    }
+
+    function loadApiToken() {
+      $.ajax({
+        type: 'GET',
+        url: base + 'aerosalloyalty/application/get-api-token',
+        data: { value_id: value_id },
+        dataType: 'json'
+      })
+      .done(function(res) {
+        if (res && res.error) {
+          msg(res);
+          return;
+        }
+        setApiToken(res.token || '', res.last_used_at || '');
+      })
+      .fail(function(err) {
+        console.log(err);
+        msg({ message: '<?php echo p__("Aerosalloyalty", "Unable to load API token"); ?>' });
+      });
+    }
+
+    $('#btn_regenerate_api_token').on('click', function() {
+      if (!confirm('<?php echo p__("Aerosalloyalty", "Regenerate token? Existing integrations will need the new value."); ?>')) {
+        return;
+      }
+
+      $.ajax({
+        type: 'POST',
+        url: base + 'aerosalloyalty/application/regenerate-api-token',
+        data: { value_id: value_id },
+        dataType: 'json'
+      })
+      .done(function(res) {
+        if (res && res.error) {
+          msg(res);
+          return;
+        }
+        setApiToken(res.token || '', res.last_used_at || '');
+        msg({ success: 1, message: '<?php echo p__("Aerosalloyalty", "Token regenerated"); ?>' });
+      })
+      .fail(function(err) {
+        console.log(err);
+        msg({ message: '<?php echo p__("Aerosalloyalty", "Unable to regenerate token"); ?>' });
+      });
+    });
+
+    $('#btn_copy_api_token').on('click', function() {
+      if (!api_token) {
+        msg({ message: '<?php echo p__("Aerosalloyalty", "No token available yet"); ?>' });
+        return;
+      }
+
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(api_token)
+          .then(function() {
+            msg({ success: 1, message: '<?php echo p__("Aerosalloyalty", "Token copied to clipboard"); ?>' });
+          })
+          .catch(function() {
+            msg({ message: '<?php echo p__("Aerosalloyalty", "Unable to copy token"); ?>' });
+          });
+        return;
+      }
+
+      var $input = $('#api_token_value');
+      var wasReadonly = $input.prop('readonly');
+      $input.prop('readonly', false).focus().select();
+      try {
+        document.execCommand('copy');
+        msg({ success: 1, message: '<?php echo p__("Aerosalloyalty", "Token copied"); ?>' });
+      } catch (e) {
+        msg({ message: '<?php echo p__("Aerosalloyalty", "Unable to copy token"); ?>' });
+      }
+      $input.prop('readonly', wasReadonly);
+    });
 
     // ---------- BOOT ----------
     init();


### PR DESCRIPTION
## Summary
- harden model helpers by ignoring soft-deleted cards and adding campaign UID/API token utilities
- add a public campaigns controller that validates Bearer tokens, persists campaigns, and logs all requests
- surface token management in the admin UI with regeneration/copy actions and document the public API

## Testing
- php -l controllers/Public/CampaignController.php
- php -l Model/Campaign.php
- php -l Model/ApiToken.php

------
https://chatgpt.com/codex/tasks/task_e_68da4e69f12883269a1e80a2c227dd89